### PR TITLE
Introduces new "env_var" and "file" fields to Secret to allow specifying name/mountPath on injection #minor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,5 +147,3 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
-
-replace github.com/flyteorg/flyteidl => /home/geert/git/flyte/flyteidl

--- a/go.mod
+++ b/go.mod
@@ -147,3 +147,5 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
+
+replace github.com/flyteorg/flyteidl => /home/geert/git/flyte/flyteidl

--- a/pkg/compiler/test/testdata/snacks-core/012_core.containerization.use_secrets.secret_task_1_task.yaml
+++ b/pkg/compiler/test/testdata/snacks-core/012_core.containerization.use_secrets.secret_task_1_task.yaml
@@ -43,6 +43,7 @@ template:
       version: 0.32.6
   security_context:
     secrets:
-    - group: user-info
+    - MountTarget: null
+      group: user-info
       key: user_secret
   type: python-task

--- a/pkg/compiler/test/testdata/snacks-core/013_core.containerization.use_secrets.user_info_task_1_task.yaml
+++ b/pkg/compiler/test/testdata/snacks-core/013_core.containerization.use_secrets.user_info_task_1_task.yaml
@@ -48,8 +48,10 @@ template:
       version: 0.32.6
   security_context:
     secrets:
-    - group: user-info
+    - MountTarget: null
+      group: user-info
       key: username
-    - group: user-info
+    - MountTarget: null
+      group: user-info
       key: password
   type: python-task

--- a/pkg/compiler/test/testdata/snacks-core/014_core.containerization.use_secrets.secret_file_task_1_task.yaml
+++ b/pkg/compiler/test/testdata/snacks-core/014_core.containerization.use_secrets.secret_file_task_1_task.yaml
@@ -48,7 +48,8 @@ template:
       version: 0.32.6
   security_context:
     secrets:
-    - group: user-info
+    - MountTarget: null
+      group: user-info
       key: user_secret
       mount_requirement: 1
   type: python-task

--- a/pkg/compiler/test/testdata/snacks-core/compiled/012_core.containerization.use_secrets.secret_task_1_task.yaml
+++ b/pkg/compiler/test/testdata/snacks-core/compiled/012_core.containerization.use_secrets.secret_task_1_task.yaml
@@ -50,6 +50,7 @@ template:
       version: 0.32.6
   security_context:
     secrets:
-    - group: user-info
+    - MountTarget: null
+      group: user-info
       key: user_secret
   type: python-task

--- a/pkg/compiler/test/testdata/snacks-core/compiled/013_core.containerization.use_secrets.user_info_task_1_task.yaml
+++ b/pkg/compiler/test/testdata/snacks-core/compiled/013_core.containerization.use_secrets.user_info_task_1_task.yaml
@@ -55,8 +55,10 @@ template:
       version: 0.32.6
   security_context:
     secrets:
-    - group: user-info
+    - MountTarget: null
+      group: user-info
       key: username
-    - group: user-info
+    - MountTarget: null
+      group: user-info
       key: password
   type: python-task

--- a/pkg/compiler/test/testdata/snacks-core/compiled/014_core.containerization.use_secrets.secret_file_task_1_task.yaml
+++ b/pkg/compiler/test/testdata/snacks-core/compiled/014_core.containerization.use_secrets.secret_file_task_1_task.yaml
@@ -55,7 +55,8 @@ template:
       version: 0.32.6
   security_context:
     secrets:
-    - group: user-info
+    - MountTarget: null
+      group: user-info
       key: user_secret
       mount_requirement: 1
   type: python-task

--- a/pkg/compiler/test/testdata/snacks-core/compiled/015_core.containerization.use_secrets.my_secret_workflow_2_wf.yaml
+++ b/pkg/compiler/test/testdata/snacks-core/compiled/015_core.containerization.use_secrets.my_secret_workflow_2_wf.yaml
@@ -226,7 +226,8 @@ tasks:
         version: 0.32.6
     security_context:
       secrets:
-      - group: user-info
+      - MountTarget: null
+        group: user-info
         key: user_secret
         mount_requirement: 1
     type: python-task
@@ -282,7 +283,8 @@ tasks:
         version: 0.32.6
     security_context:
       secrets:
-      - group: user-info
+      - MountTarget: null
+        group: user-info
         key: user_secret
     type: python-task
 - template:
@@ -342,8 +344,10 @@ tasks:
         version: 0.32.6
     security_context:
       secrets:
-      - group: user-info
+      - MountTarget: null
+        group: user-info
         key: username
-      - group: user-info
+      - MountTarget: null
+        group: user-info
         key: password
     type: python-task

--- a/pkg/webhook/global_secrets.go
+++ b/pkg/webhook/global_secrets.go
@@ -30,6 +30,7 @@ func (g GlobalSecrets) Type() config.SecretManagerType {
 }
 
 func (g GlobalSecrets) Inject(ctx context.Context, secret *coreIdl.Secret, p *corev1.Pod) (newP *corev1.Pod, injected bool, err error) {
+
 	v, err := g.envSecretManager.GetForSecret(ctx, secret)
 	if err != nil {
 		return p, false, err

--- a/pkg/webhook/k8s_secrets.go
+++ b/pkg/webhook/k8s_secrets.go
@@ -50,12 +50,12 @@ func (i K8sSecretInjector) Inject(ctx context.Context, secret *core.Secret, p *c
 		case *core.Secret_EnvVar:
 			target, ok := secret.GetMountTarget().(*core.Secret_EnvVar)
 			if ok {
-				injectSecretAsEnvVar(p, secret, &target.EnvVar.Name)
+				InjectSecretAsEnvVar(p, secret, &target.EnvVar.Name)
 			}
 		case *core.Secret_File:
 			target, ok := secret.GetMountTarget().(*core.Secret_File)
 			if ok {
-				injectSecretAsFile(p, secret, &target.File.Path)
+				InjectSecretAsFile(p, secret, &target.File.Path)
 			}
 		default:
 			err := fmt.Errorf("unrecognized mount target [%v] for secret [%v]", secret.GetMountTarget(), secret.Key)
@@ -67,9 +67,9 @@ func (i K8sSecretInjector) Inject(ctx context.Context, secret *core.Secret, p *c
 		case core.Secret_ANY:
 			fallthrough
 		case core.Secret_FILE:
-			injectSecretAsFile(p, secret, nil)
+			InjectSecretAsFile(p, secret, nil)
 		case core.Secret_ENV_VAR:
-			injectSecretAsEnvVar(p, secret, nil)
+			InjectSecretAsEnvVar(p, secret, nil)
 		default:
 			err := fmt.Errorf("unrecognized mount requirement [%v] for secret [%v]", secret.MountRequirement.String(), secret.Key)
 			logger.Error(ctx, err)
@@ -84,7 +84,7 @@ func NewK8sSecretsInjector() K8sSecretInjector {
 	return K8sSecretInjector{}
 }
 
-func injectSecretAsFile(p *corev1.Pod, secret *core.Secret, mountPath *string) {
+func InjectSecretAsFile(p *corev1.Pod, secret *core.Secret, mountPath *string) {
 	// Inject a Volume that to the pod and all of its containers and init containers that mounts the secret into a
 	// file.
 	volume := CreateVolumeForSecret(secret)
@@ -117,7 +117,7 @@ func injectSecretAsFile(p *corev1.Pod, secret *core.Secret, mountPath *string) {
 	p.Spec.Containers = AppendEnvVars(p.Spec.Containers, prefixEnvVar)
 }
 
-func injectSecretAsEnvVar(p *corev1.Pod, secret *core.Secret, envVarName *string) {
+func InjectSecretAsEnvVar(p *corev1.Pod, secret *core.Secret, envVarName *string) {
 	envVar := CreateEnvVarForSecret(secret)
 	if envVarName != nil {
 		envVar = CreateNamedEnvVarForSecret(secret, *envVarName)

--- a/pkg/webhook/k8s_secrets.go
+++ b/pkg/webhook/k8s_secrets.go
@@ -77,6 +77,7 @@ func (i K8sSecretInjector) Inject(ctx context.Context, secret *core.Secret, p *c
 		p.Spec.Containers = AppendEnvVars(p.Spec.Containers, prefixEnvVar)
 	case core.Secret_ENV_VAR:
 		envVar := CreateEnvVarForSecret(secret)
+
 		p.Spec.InitContainers = AppendEnvVars(p.Spec.InitContainers, envVar)
 		p.Spec.Containers = AppendEnvVars(p.Spec.Containers, envVar)
 

--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -26,8 +26,12 @@ func hasEnvVar(envVars []corev1.EnvVar, envVarKey string) bool {
 
 func CreateEnvVarForSecret(secret *core.Secret) corev1.EnvVar {
 	optional := true
+	secretName := strings.ToUpper(K8sDefaultEnvVarPrefix + secret.Group + EnvVarGroupKeySeparator + secret.Key)
+	if len(secret.EnvName) != 0 {
+		secretName = secret.EnvName
+	}
 	return corev1.EnvVar{
-		Name: strings.ToUpper(K8sDefaultEnvVarPrefix + secret.Group + EnvVarGroupKeySeparator + secret.Key),
+		Name: secretName,
 		ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -26,12 +26,25 @@ func hasEnvVar(envVars []corev1.EnvVar, envVarKey string) bool {
 
 func CreateEnvVarForSecret(secret *core.Secret) corev1.EnvVar {
 	optional := true
-	secretName := strings.ToUpper(K8sDefaultEnvVarPrefix + secret.Group + EnvVarGroupKeySeparator + secret.Key)
-	if len(secret.EnvName) != 0 {
-		secretName = secret.EnvName
-	}
+	envVarName := strings.ToUpper(K8sDefaultEnvVarPrefix + secret.Group + EnvVarGroupKeySeparator + secret.Key)
 	return corev1.EnvVar{
-		Name: secretName,
+		Name: envVarName,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secret.Group,
+				},
+				Key:      secret.Key,
+				Optional: &optional,
+			},
+		},
+	}
+}
+
+func CreateNamedEnvVarForSecret(secret *core.Secret, envVarName string) corev1.EnvVar {
+	optional := true
+	return corev1.EnvVar{
+		Name: envVarName,
 		ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -69,6 +82,14 @@ func CreateVolumeMountForSecret(volumeName string, secret *core.Secret) corev1.V
 		Name:      volumeName,
 		ReadOnly:  true,
 		MountPath: filepath.Join(filepath.Join(K8sSecretPathPrefix...), strings.ToLower(secret.Group)),
+	}
+}
+
+func CreateVolumeMountForSecretWithMountPath(volumeName string, secret *core.Secret, mountPath string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      volumeName,
+		ReadOnly:  true,
+		MountPath: mountPath,
 	}
 }
 


### PR DESCRIPTION
# TL;DR
Introduces new fields to the `Secret` object:
- `env_var`
- `file`

Allowing users to directly specify a name or mountPath for the Secret, without having to specify a full PodTemplate(name). The old `mount_requirement` can still be used. Example:

```python

from flytekit import task, workflow, Secret
import flytekit
import os


@task(
    secret_requests=[
        Secret(
            group="user-info",
            key="user_secret",
            mount_requirement=Secret.MountType.FILE,
        ),
        Secret(
            group="user-info",
            key="user_secret",
            mount_requirement=Secret.MountType.ENV_VAR,
        ),
    ]
)
def old() -> None:
    context = flytekit.current_context()
    print("old")

    # mount_requirement=ENV_VAR
    print(context.secrets.get(env_name="_FSEC_USER-INFO_USER_SECRET"))

    # mount_requirement=FILE
    with open('/etc/flyte/secrets/user-info/user_secret', 'r') as infile:
        print(infile.readlines())
    return True

@task(
    secret_requests=[
        Secret(
            group="user-info",
            key="user_secret",
            env_var=Secret.MountEnvVar(name="foo"),
        ),
        Secret(
            group="user-info",
            key="user_secret",
            file=Secret.MountFile(path="/foo"),
        ),
    ]
)

def new() -> None:
    context = flytekit.current_context()
    print("new")

    # env_var=
    print(context.secrets.get(env_name="foo"))

    # file=
    with open('/foo/user_secret', 'r') as infile:
        print(infile.readlines())


@workflow
def training_workflow(hyperparameters: dict) -> None:
    """Put all of the steps together into a single workflow."""
    old()
    new()

```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
